### PR TITLE
chore: fix tsc npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "indexer"
   ],
   "scripts": {
-    "lint": "prettier --check . && standard && tsc -p .",
+    "lint": "prettier --check . && standard",
     "lint:fix": "prettier --write . && standard --fix .",
-    "pretest": "npm run lint",
-    "test": "npm test --workspaces --if-present"
+    "test:types": "tsc -p .",
+    "test:unit": "npm test --workspaces --if-present",
+    "test": "npm run lint && npm run test:types && npm run test:unit"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Move type-checking from `lint` to `test:types`.

Inspired by https://github.com/filecoin-station/spark-evaluate/blob/f87560ec447d41ecaaadd3eafc7ab33d8eb2e078/package.json#L7-L10

Links:
- https://github.com/filecoin-station/piece-indexer/pull/4#discussion_r1743312296
- https://github.com/space-meridian/roadmap/issues/143
