### PR TITLE
feat: move the API to https://pix.filspark.com

### DIFF
--- a/api/fly.toml
+++ b/api/fly.toml
@@ -7,7 +7,7 @@ processes = []
 [env]
   PORT = "8080"
   HOST = "0.0.0.0"
-  DOMAIN = "spark-piece-indexer-api.fly.dev"
+  DOMAIN = "pix.filspark.com"
   SENTRY_ENVIRONMENT = "production"
   REQUEST_LOGGING = "false"
   NPM_CONFIG_WORKSPACE = "api"


### PR DESCRIPTION
I configured Cloudflare to act as a caching reverse proxy.

Links:
- https://github.com/space-meridian/roadmap/issues/143
