### PR TITLE
fix: don't log 404 error when fetching entries

### DIFF
--- a/indexer/lib/advertisement-walker.js
+++ b/indexer/lib/advertisement-walker.js
@@ -298,7 +298,8 @@ export async function fetchAdvertisedPayload (providerAddress, advertisementCid,
     // We are not able to fetch the advertised entries. Skip this advertisement so that we can
     // continue the ingestion of other advertisements.
     const errorDescription = describeFetchError(err, providerAddress)
-    console.warn(
+    const log = /** @type {any} */(err)?.statusCode === 404 ? debug : console.warn
+    log(
       'Cannot fetch ad %s entries %s: %s',
       advertisementCid,
       entriesCid,


### PR DESCRIPTION
This is a follow-up for https://github.com/filecoin-station/piece-indexer/pull/23, I don't want to spam our logs with non-actionable errors and have a huge Papertrail bill.
