### PR TITLE
feat: expose adsMissingPieceCID and entriesNotRetrievable

### DIFF
--- a/api/lib/handler.js
+++ b/api/lib/handler.js
@@ -102,6 +102,8 @@ async function getProviderIngestionStatus (req, res, repository, providerId) {
     // Is it a problem if our observability API does not tell the provider address?
     ingestionStatus: walkerState.status,
     lastHeadWalkedFrom: walkerState.lastHead ?? walkerState.head,
+    adsMissingPieceCID: walkerState.adsMissingPieceCID ?? 0,
+    entriesNotRetrievable: walkerState.entriesNotRetrievable ?? 0,
     piecesIndexed: await repository.countPiecesIndexed(providerId)
   })
 }

--- a/api/test/handler.test.js
+++ b/api/test/handler.test.js
@@ -123,6 +123,8 @@ describe('HTTP request handler', () => {
         // providerAddress: "state.providerAddress",
         ingestionStatus: 'walking',
         lastHeadWalkedFrom: 'last-head',
+        adsMissingPieceCID: 0,
+        entriesNotRetrievable: 0,
         piecesIndexed: 1
       })
 
@@ -167,7 +169,36 @@ describe('HTTP request handler', () => {
         providerId: 'provider-id',
         ingestionStatus: 'walking',
         lastHeadWalkedFrom: 'head',
+        adsMissingPieceCID: 0,
+        entriesNotRetrievable: 0,
         piecesIndexed: 1
+      })
+
+      assert.strictEqual(
+        res.headers.get('cache-control'),
+          `public, max-age=${60}`
+      )
+    })
+
+    it('returns the number of adsMissingPieceCID and entriesNotRetrievable', async () => {
+      await repository.setWalkerState('provider-id', {
+        status: 'walking',
+        head: 'head',
+        entriesNotRetrievable: 10,
+        adsMissingPieceCID: 20
+      })
+
+      const res = await fetch(new URL('/ingestion-status/provider-id', baseUrl))
+      await assertResponseStatus(res, 200)
+      const body = await res.json()
+
+      assert.deepStrictEqual(body, {
+        providerId: 'provider-id',
+        ingestionStatus: 'walking',
+        lastHeadWalkedFrom: 'head',
+        entriesNotRetrievable: 10,
+        adsMissingPieceCID: 20,
+        piecesIndexed: 0
       })
 
       assert.strictEqual(


### PR DESCRIPTION
This is a follow-up for https://github.com/filecoin-station/piece-indexer/pull/23 to expose the new ingestion status fields via REST API.

Links:
- https://github.com/space-meridian/roadmap/issues/143